### PR TITLE
Move port and IP into env_config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,28 @@ cd  ~/ark_manager_web
 bundle exec unicorn -c ./config/unicorn.rb -D
 ```
 This will allow the interface to be visible from `127.0.0.1:8080` of the machine its set up on.
-If you wish to change this edit the `/path/to/ark_manager_web/config/unicorn.rb` file and change the listening field.
+
+If you wish to change this edit the `/path/to/ark_manager_web/config/env_config.json` file.
+The only following allowed options are available:
+
+| option  | description |
+|---------|-------------|
+| port    | which port to bind    |
+| address | which address to bind |
+| memcache_port | same for memcache |
+| memcache_addrss | same for memcache |
+| arkamanger_path | /some/path/to/bin/where/arkmanager/is |
+
+```json
+{
+  "port": "8888",
+  "address": "127.0.0.1",
+  "memcache_port": "11212",
+  "memcache_address": "192.168.1.5",  // pretend you have local network in cloud :)
+  "arkmanager_path": "/usr/local/bin"
+}
+```
+
 ## Recommendations
 It is recommended to set this up behind a `nginx` reverse proxy as well as enabling `ufw` to block
 access to port 8080. That will prevent unwanted insecure access to the web interface. The next

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -34,8 +34,19 @@ else
   $logger.level = Logger::DEBUG
 end
 
+# this is default ones
+memcache_port = '11211'
+memcache_address = 'localhost'
+
+if File.exists?("#{WORKING_DIR}/config/env_config.json")
+  hash = Oj.load_file("#{WORKING_DIR}/config/env_config.json", Hash.new)
+  memcache_port = hash['port'] || memcache_port
+  memcache_address = hash['address'] || memcache_address
+end
+
+
 $scheduler = Rufus::Scheduler.new unless defined?($scheduler)
-$dalli_cache = Dalli::Client.new('localhost:11211', { namespace: 'boop_on_your_nose', compress: true }) unless defined?($dalli_cache)
+$dalli_cache = Dalli::Client.new(memcache_address << ':' << memcache_port, { namespace: 'boop_on_your_nose', compress: true }) unless defined?($dalli_cache)
 $dalli_cache.flush_all
 
 

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -22,7 +22,7 @@ ENV["TZ"] = ENV.fetch("TZ", "Etc/UTC")
 
 DOMAIN_NAME = ENV.fetch('DOMAIN_NAME', 'localhost')
 
-raise 'I was unable to find arkmanager in your path!! please run "bundle exec rake install_server_tools"' unless ARK_MANAGER_CLI
+raise 'I was unable to find arkmanager in your path!! please run "bundle exec rake install:server_tools"' unless ARK_MANAGER_CLI
 raise 'I was unable to find memcached!!! please have your system administrator install memcached' unless find_executable('memcached')
 
 $logger = Logger.new(STDOUT)

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -6,25 +6,26 @@ require 'logger'
 require 'base64'
 require 'rufus-scheduler'
 
-WORKING_DIR       = File.dirname(File.expand_path('..', __FILE__)) unless defined?(WORKING_DIR)
-EGREP_EXEC        = find_executable 'egrep'
-CURL_EXEC         = find_executable 'curl'
-USER_HOME         = Dir.home unless defined?(USER_HOME)
-RACK_ENV          = ENV.fetch('RACK_ENV', 'development')
-ARK_MANAGER_CLI   = find_executable('arkmanager', "#{USER_HOME}/bin") unless defined?(ARK_MANAGER_CLI)
+WORKING_DIR          = File.dirname(File.expand_path('..', __FILE__)) unless defined?(WORKING_DIR)
+EGREP_EXEC           = find_executable 'egrep'
+CURL_EXEC            = find_executable 'curl'
+USER_HOME            = Dir.home unless defined?(USER_HOME)
+ARK_MANAGER_CLI_PATH = "#{USER_HOME}/bin" unless defined?(ARK_MANAGER_CLI_PATH)
+RACK_ENV             = ENV.fetch('RACK_ENV', 'development')
 
 memcache_port = '11211'
 memcache_address = 'localhost'
 if File.exists?("#{WORKING_DIR}/config/env_config.json")
   hash = Oj.load_file("#{WORKING_DIR}/config/env_config.json", Hash.new)
   hash.each_pair { |key,value|  ENV[key] = value  }
-  memcache_port = hash['port'] || memcache_port
-  memcache_address = hash['address'] || memcache_address
+  memcache_port        = ENV['memcache_port'] || memcache_port
+  memcache_address     = ENV['memcache_address'] || memcache_address
+  ARK_MANAGER_CLI_PATH = ENV['arkmanager_path'] || ARK_MANAGER_CLI_PATH
 end
 
+ARK_MANAGER_CLI = find_executable('arkmanager', ARK_MANAGER_CLI_PATH) unless defined?(ARK_MANAGER_CLI)
+DOMAIN_NAME     = ENV.fetch('DOMAIN_NAME', 'localhost')
 ENV["TZ"] = ENV.fetch("TZ", "Etc/UTC")
-
-DOMAIN_NAME = ENV.fetch('DOMAIN_NAME', 'localhost')
 
 raise 'I was unable to find arkmanager in your path!! please run "bundle exec rake install:server_tools"' unless ARK_MANAGER_CLI
 raise 'I was unable to find memcached!!! please have your system administrator install memcached' unless find_executable('memcached')

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,3 +1,5 @@
+require 'oj'
+
 WORKING_DIR = File.dirname(File.expand_path('..', __FILE__))
 working_directory WORKING_DIR
 
@@ -7,4 +9,14 @@ stdout_path WORKING_DIR + '/log/unicorn.stderr.log'
 
 worker_processes 1
 
-listen '0.0.0.0:8080'
+# this is default ones
+port = '8080'
+address = '0.0.0.0'
+
+if File.exists?("#{WORKING_DIR}/config/env_config.json")
+  hash = Oj.load_file("#{WORKING_DIR}/config/env_config.json", Hash.new)
+  port = hash['port'] || port
+  address = hash['address'] || address
+end
+
+listen address << ':' << port


### PR DESCRIPTION
It's really not that right when you want to use ark-manager-web master branch but you want to have different ip and port binding - you'd gonna have edited `unicorn.rb` file which would be changed in future possibly and this will force you to ``stash`` changes, ``pull``, then ``stash pop`` and maybe resolve some conflicts and so on.

This PR should solve it.