### PR TITLE
Added ability to change the port and address via config

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -15,11 +15,12 @@ address = '0.0.0.0'
 env_config_path = "#{WORKING_DIR}/config/env_config.json"
 
 if File.exist?(env_config_path)
-	file = File.read(env_config_path)
-	hash = JSON.parse!(file, symbolize_names: true)
-  # hash = Oj.load_file("#{WORKING_DIR}/config/env_config.json", Hash.new)
-  port = hash[:port] || port
-  address = hash[:address] || address
+  file = File.read(env_config_path)
+  hash = JSON.parse!(file, symbolize_names: true)
+  hash.each_pair {|key, value| ENV[key.to_s] = value.to_s}
 end
+
+port = ENV.fetch('PORT', port)
+address = ENV.fetch('ADDRESS', address)
 
 listen format('%s:%s', address, port)

--- a/lib/tasks/configure.rake
+++ b/lib/tasks/configure.rake
@@ -28,7 +28,9 @@ task :configure do
 			ARKMANAGER_PATH: cli.ask('What is the arkmanager path?  ') { |q| q.default = "#{Dir.home}/bin" },
 			ARK_INSTANCE_NAME: cli.ask('What is the ark instance name?  ') { |q| q.default = 'main' },
 			MEMCACHE_ADDRESS:cli.ask('What is the memcached ip address?  ') { |q| q.default = '127.0.0.1' },
-			MEMCACHE_PORT: cli.ask('What is the memcached port?  ', Integer) { |q| q.default = '11211' }
+			MEMCACHE_PORT: cli.ask('What is the memcached port?  ', Integer) { |q| q.default = '11211' },
+			ADDRESS: cli.ask('What is the webserver ip address?  ') { |q| q.default = '127.0.0.1' },
+			PORT: cli.ask('What is the webserver port?  ', Integer) { |q| q.default = '8080' }
 		}
 	end
 


### PR DESCRIPTION
As the title says I added the ability to change the address and port for the webserver from the config file.
A simple JSON config would play out something like:

{
  "ARKMANAGER_PATH": "<home>/bin",
  "ARK_INSTANCE_NAME": "valg",
  "MEMCACHE_ADDRESS": "127.0.0.1",
  "MEMCACHE_PORT": 11211,
  "ADDRESS": "127.0.0.1",
  "PORT": 8080
}

I hope this helps anyone from having to go into the unicorn file themselves and changing it.
I also made it able to be setup on first launch.

One more thing I would like to mention, this ruby program fully works on ruby 2.4.6 I haven't tested on newer, but I couldn't install anything prior to 2.4 because those ruby versions don't like openssl 1.1.x