### PR TITLE
Fix dead ATiltedTree/setup-rust action in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,9 @@ jobs:
           node-version: '24'
 
       - name: Setup | Rust | Nightly
-        uses: ATiltedTree/setup-rust@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          rust-version: nightly
-          components: clippy rustfmt
+          components: clippy, rustfmt
 
       - uses: davidB/rust-cargo-make@v1
         name: Install Cargo Make


### PR DESCRIPTION
## Summary
- \`ATiltedTree/setup-rust\` no longer resolves (\`Unable to resolve action atiltedtree/setup-rust, repository not found\`), which was failing every \`Release\` run on \`main\` at the action-resolution step, before any of the actual release steps even ran — unrelated to the paws conversion in #2032.
- Swaps it for \`dtolnay/rust-toolchain@nightly\` (same maintained action \`rust.yml\`/\`docker.yml\` already build on transitively via \`paws-up\`'s CI), keeping the same \`clippy\`+\`rustfmt\` components the \`cargo-make -p production release\` step needs.

## Test plan
- [x] YAML parses
- [ ] Watch the \`Release\` job on this PR / after merge to confirm the toolchain setup step now succeeds