### PR TITLE
Verify paws docker after mbround18/paws#4

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ docker run -d \
 
   <img src="./docs/assets/steamcmd-not-found.png" alt="drawing" style="width:25em;"/>
 
+


### PR DESCRIPTION
No-op PR to re-exercise docker.yml's build (PR mode: build only, no push) now that paws v0.0.1-prerelease.14 (mbround18/paws#4) fixes paws docker's exit-code bug. That bug was masking a real Dagger "failed to load container from converted ID" error on the Build web leg (building ./Dockerfile, the one with FROM mbround18/ark-manager-client:latest) on a prior run against main. Checking whether it reproduces now.

Not meant to merge - closing once it's told us what we need to know.